### PR TITLE
Windows compatibility

### DIFF
--- a/pyache.py
+++ b/pyache.py
@@ -32,7 +32,7 @@ class Pyache:
     """
 
     @property
-    def file_delimiter(self):
+    def file_delimiter(self) -> str:
         """
         Returns:
             an OS dependent string used as a delimiter in file names to improve readability.

--- a/pyache.py
+++ b/pyache.py
@@ -31,12 +31,12 @@ class Pyache:
         max_loaders: Maximum number of loader caches before others are deleted
     """
 
-    """
-    Returns:
-        an OS dependent string used as a delimiter in file names to improve readability.
-    """
     @property
     def file_delimiter(self):
+        """
+        Returns:
+            an OS dependent string used as a delimiter in file names to improve readability.
+        """
         if os_name == "nt":
             return "_"
         else:


### PR DESCRIPTION
Adding Windows compatibility by using a different file name delimiter.

Uses the old delimiter when not on Windows to preserve backwards compatibility.